### PR TITLE
feat: Include working directory in PR comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
       env:
         PULUMI_STACK: ${{ inputs.stack }}
         PULUMI_CONFIG_PASSPHRASE: ${{ inputs.passphrase }}
+        WORKING_DIR: ${{ inputs.working_directory }}
       shell: bash
       id: main
       working-directory: ${{ inputs.working_directory }}

--- a/main.sh
+++ b/main.sh
@@ -15,7 +15,6 @@ export PULUMI_SELF_MANAGED_STATE_LOCKING=1
 outputStdOut=$(mktemp)
 outputStdErr=$(mktemp)
 
-workingDir="$2"
 function main {
   command="$1"
   scriptDir=$(dirname ${0})

--- a/preview.sh
+++ b/preview.sh
@@ -25,7 +25,7 @@ function pulumiPreview {
     if [ -z $GITHUB_TOKEN ]; then
       echo "ERROR: GITHUB_TOKEN is not set."
     else
-      COMMENT="#### \`pulumi preview\`
+      COMMENT="#### \`pulumi preview\` for \`${WORKING_DIR}\`
 <details>
   <summary>Details</summary>
 


### PR DESCRIPTION
It is common to want to separate your stacks and use something like a
workflow matrix to execute each in parallel. This could cause multiple
comments and it would be hard to know which one is which until you
expand the diff. By adding the directory to the output, this should help
solve that problem.
